### PR TITLE
feat: introduce multi-agent swarm with handoffs

### DIFF
--- a/src/apeswarm/agents/__init__.py
+++ b/src/apeswarm/agents/__init__.py
@@ -1,0 +1,5 @@
+from .builder_ape import builder_ape_response
+from .git_ape import git_ape_response
+from .sarcastic_ape import sarcastic_ape_response
+
+__all__ = ["sarcastic_ape_response", "builder_ape_response", "git_ape_response"]

--- a/src/apeswarm/agents/builder_ape.py
+++ b/src/apeswarm/agents/builder_ape.py
@@ -1,0 +1,24 @@
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+
+def builder_ape_response(model, goal: str, sarcastic_context: str) -> str:
+	prompt = ChatPromptTemplate.from_messages(
+		[
+			(
+				"system",
+				"""You are BuilderApe in ApeSwarm.
+Convert strategy into practical implementation output.
+Produce concise markdown with sections exactly:
+1) Build Plan
+2) Proposed File Changes
+3) Handoff to GitApe""",
+			),
+			(
+				"human",
+				"Goal:\n{goal}\n\nSarcasticApe Guidance:\n{sarcastic_context}",
+			),
+		]
+	)
+	chain = prompt | model | StrOutputParser()
+	return chain.invoke({"goal": goal, "sarcastic_context": sarcastic_context})

--- a/src/apeswarm/agents/git_ape.py
+++ b/src/apeswarm/agents/git_ape.py
@@ -1,0 +1,25 @@
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+
+def git_ape_response(model, goal: str, builder_output: str) -> str:
+	prompt = ChatPromptTemplate.from_messages(
+		[
+			(
+				"system",
+				"""You are GitApe in ApeSwarm.
+You are responsible for git strategy and delivery hygiene.
+Respond with concise markdown sections exactly:
+1) Branch Name
+2) Commit Message
+3) PR Title
+4) Merge Checklist""",
+			),
+			(
+				"human",
+				"Goal:\n{goal}\n\nBuilderApe Output:\n{builder_output}",
+			),
+		]
+	)
+	chain = prompt | model | StrOutputParser()
+	return chain.invoke({"goal": goal, "builder_output": builder_output})

--- a/src/apeswarm/agents/sarcastic_ape.py
+++ b/src/apeswarm/agents/sarcastic_ape.py
@@ -1,0 +1,22 @@
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+
+def sarcastic_ape_response(model, goal: str) -> str:
+	prompt = ChatPromptTemplate.from_messages(
+		[
+			(
+				"system",
+				"""You are SarcasticApe, founder of ApeSwarm.
+Maximum sarcasm. Zero tolerance for mediocre ideas.
+Roast the goal if needed, then route execution for shipping.
+Return concise sections exactly:
+1) Roast
+2) Strategy
+3) Handoff to BuilderApe""",
+			),
+			("human", "Goal: {goal}"),
+		]
+	)
+	chain = prompt | model | StrOutputParser()
+	return chain.invoke({"goal": goal})

--- a/src/apeswarm/core/orchestrator.py
+++ b/src/apeswarm/core/orchestrator.py
@@ -1,0 +1,107 @@
+from typing import TypedDict
+
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from apeswarm.agents import builder_ape_response, git_ape_response, sarcastic_ape_response
+from apeswarm.core.model_factory import get_model
+
+
+class SwarmState(TypedDict):
+	goal: str
+	active_agent: str
+	sarcastic_output: str
+	builder_output: str
+	git_output: str
+
+
+class SwarmEvent(TypedDict):
+	agent: str
+	content: str
+
+
+_CHECKPOINTER = MemorySaver()
+_APP = None
+
+
+def _build_app():
+	model = get_model()
+
+	def sarcastic_ape_node(state: SwarmState) -> SwarmState:
+		return {
+			"goal": state["goal"],
+			"active_agent": "BuilderApe",
+			"sarcastic_output": sarcastic_ape_response(model, state["goal"]),
+			"builder_output": state["builder_output"],
+			"git_output": state["git_output"],
+		}
+
+	def builder_ape_node(state: SwarmState) -> SwarmState:
+		return {
+			"goal": state["goal"],
+			"active_agent": "GitApe",
+			"sarcastic_output": state["sarcastic_output"],
+			"builder_output": builder_ape_response(
+				model=model,
+				goal=state["goal"],
+				sarcastic_context=state["sarcastic_output"],
+			),
+			"git_output": state["git_output"],
+		}
+
+	def git_ape_node(state: SwarmState) -> SwarmState:
+		return {
+			"goal": state["goal"],
+			"active_agent": "done",
+			"sarcastic_output": state["sarcastic_output"],
+			"builder_output": state["builder_output"],
+			"git_output": git_ape_response(
+				model=model,
+				goal=state["goal"],
+				builder_output=state["builder_output"],
+			),
+		}
+
+	graph_builder = StateGraph(SwarmState)
+	graph_builder.add_node("sarcastic_ape", sarcastic_ape_node)
+	graph_builder.add_node("builder_ape", builder_ape_node)
+	graph_builder.add_node("git_ape", git_ape_node)
+	graph_builder.add_edge(START, "sarcastic_ape")
+	graph_builder.add_edge("sarcastic_ape", "builder_ape")
+	graph_builder.add_edge("builder_ape", "git_ape")
+	graph_builder.add_edge("git_ape", END)
+	return graph_builder.compile(checkpointer=_CHECKPOINTER)
+
+
+def _get_app():
+	global _APP
+	if _APP is None:
+		_APP = _build_app()
+	return _APP
+
+
+def execute_swarm(goal: str, thread_id: str = "default") -> tuple[list[SwarmEvent], SwarmState]:
+	app = _get_app()
+	initial_state: SwarmState = {
+		"goal": goal,
+		"active_agent": "SarcasticApe",
+		"sarcastic_output": "",
+		"builder_output": "",
+		"git_output": "",
+	}
+
+	config = {"configurable": {"thread_id": thread_id}}
+	events: list[SwarmEvent] = []
+	current_state = initial_state.copy()
+
+	for update in app.stream(initial_state, config=config, stream_mode="updates"):
+		for node_name, patch in update.items():
+			current_state.update(patch)
+			if node_name == "sarcastic_ape" and patch.get("sarcastic_output"):
+				events.append({"agent": "SarcasticApe", "content": patch["sarcastic_output"]})
+			elif node_name == "builder_ape" and patch.get("builder_output"):
+				events.append({"agent": "BuilderApe", "content": patch["builder_output"]})
+			elif node_name == "git_ape" and patch.get("git_output"):
+				events.append({"agent": "GitApe", "content": patch["git_output"]})
+
+	return events, current_state


### PR DESCRIPTION
## Summary
- add 3-agent swarm flow: SarcasticApe -> BuilderApe -> GitApe
- add dedicated agent modules under 
- add orchestrator with LangGraph state graph and explicit handoff transitions
- update CLI to execute swarm and print each agent output with rich formatting

## Validation
- Obtaining file:///workspaces/apeswarm
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: langchain-anthropic>=0.2.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (1.3.4)
Requirement already satisfied: langchain-groq>=0.2.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (1.1.2)
Requirement already satisfied: langchain-ollama>=0.2.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (1.0.1)
Requirement already satisfied: langchain-openai>=0.2.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (1.1.10)
Requirement already satisfied: langchain>=0.3.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (1.2.10)
Requirement already satisfied: langgraph>=0.2.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (1.0.9)
Requirement already satisfied: pydantic>=2.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (2.12.5)
Requirement already satisfied: python-dotenv>=1.0.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (1.2.1)
Requirement already satisfied: rich>=13.0.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from apeswarm==0.1.0.dev0) (14.3.3)
Requirement already satisfied: langchain-core<2.0.0,>=1.2.10 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain>=0.3.0->apeswarm==0.1.0.dev0) (1.2.16)
Requirement already satisfied: jsonpatch<2.0.0,>=1.33.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (1.33)
Requirement already satisfied: langsmith<1.0.0,>=0.3.45 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (0.7.8)
Requirement already satisfied: packaging>=23.2.0 in /home/codespace/.local/lib/python3.12/site-packages (from langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (25.0)
Requirement already satisfied: pyyaml<7.0.0,>=5.3.0 in /home/codespace/.local/lib/python3.12/site-packages (from langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (6.0.3)
Requirement already satisfied: tenacity!=8.4.0,<10.0.0,>=8.1.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (9.1.4)
Requirement already satisfied: typing-extensions<5.0.0,>=4.7.0 in /home/codespace/.local/lib/python3.12/site-packages (from langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (4.15.0)
Requirement already satisfied: uuid-utils<1.0,>=0.12.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (0.14.1)
Requirement already satisfied: jsonpointer>=1.9 in /home/codespace/.local/lib/python3.12/site-packages (from jsonpatch<2.0.0,>=1.33.0->langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (3.0.0)
Requirement already satisfied: langgraph-checkpoint<5.0.0,>=2.1.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langgraph>=0.2.0->apeswarm==0.1.0.dev0) (4.0.0)
Requirement already satisfied: langgraph-prebuilt<1.1.0,>=1.0.8 in /home/codespace/.python/current/lib/python3.12/site-packages (from langgraph>=0.2.0->apeswarm==0.1.0.dev0) (1.0.8)
Requirement already satisfied: langgraph-sdk<0.4.0,>=0.3.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langgraph>=0.2.0->apeswarm==0.1.0.dev0) (0.3.9)
Requirement already satisfied: xxhash>=3.5.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langgraph>=0.2.0->apeswarm==0.1.0.dev0) (3.6.0)
Requirement already satisfied: ormsgpack>=1.12.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langgraph-checkpoint<5.0.0,>=2.1.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (1.12.2)
Requirement already satisfied: httpx>=0.25.2 in /home/codespace/.local/lib/python3.12/site-packages (from langgraph-sdk<0.4.0,>=0.3.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (0.28.1)
Requirement already satisfied: orjson>=3.11.5 in /home/codespace/.python/current/lib/python3.12/site-packages (from langgraph-sdk<0.4.0,>=0.3.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (3.11.7)
Requirement already satisfied: requests-toolbelt>=1.0.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langsmith<1.0.0,>=0.3.45->langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (1.0.0)
Requirement already satisfied: requests>=2.0.0 in /home/codespace/.local/lib/python3.12/site-packages (from langsmith<1.0.0,>=0.3.45->langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (2.32.5)
Requirement already satisfied: zstandard>=0.23.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langsmith<1.0.0,>=0.3.45->langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (0.25.0)
Requirement already satisfied: anyio in /home/codespace/.local/lib/python3.12/site-packages (from httpx>=0.25.2->langgraph-sdk<0.4.0,>=0.3.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (4.11.0)
Requirement already satisfied: certifi in /home/codespace/.local/lib/python3.12/site-packages (from httpx>=0.25.2->langgraph-sdk<0.4.0,>=0.3.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (2025.11.12)
Requirement already satisfied: httpcore==1.* in /home/codespace/.local/lib/python3.12/site-packages (from httpx>=0.25.2->langgraph-sdk<0.4.0,>=0.3.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (1.0.9)
Requirement already satisfied: idna in /home/codespace/.local/lib/python3.12/site-packages (from httpx>=0.25.2->langgraph-sdk<0.4.0,>=0.3.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (3.11)
Requirement already satisfied: h11>=0.16 in /home/codespace/.local/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.25.2->langgraph-sdk<0.4.0,>=0.3.0->langgraph>=0.2.0->apeswarm==0.1.0.dev0) (0.16.0)
Requirement already satisfied: annotated-types>=0.6.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from pydantic>=2.0->apeswarm==0.1.0.dev0) (0.7.0)
Requirement already satisfied: pydantic-core==2.41.5 in /home/codespace/.python/current/lib/python3.12/site-packages (from pydantic>=2.0->apeswarm==0.1.0.dev0) (2.41.5)
Requirement already satisfied: typing-inspection>=0.4.2 in /home/codespace/.python/current/lib/python3.12/site-packages (from pydantic>=2.0->apeswarm==0.1.0.dev0) (0.4.2)
Requirement already satisfied: anthropic<1.0.0,>=0.78.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-anthropic>=0.2.0->apeswarm==0.1.0.dev0) (0.84.0)
Requirement already satisfied: distro<2,>=1.7.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from anthropic<1.0.0,>=0.78.0->langchain-anthropic>=0.2.0->apeswarm==0.1.0.dev0) (1.9.0)
Requirement already satisfied: docstring-parser<1,>=0.15 in /home/codespace/.python/current/lib/python3.12/site-packages (from anthropic<1.0.0,>=0.78.0->langchain-anthropic>=0.2.0->apeswarm==0.1.0.dev0) (0.17.0)
Requirement already satisfied: jiter<1,>=0.4.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from anthropic<1.0.0,>=0.78.0->langchain-anthropic>=0.2.0->apeswarm==0.1.0.dev0) (0.13.0)
Requirement already satisfied: sniffio in /home/codespace/.local/lib/python3.12/site-packages (from anthropic<1.0.0,>=0.78.0->langchain-anthropic>=0.2.0->apeswarm==0.1.0.dev0) (1.3.1)
Requirement already satisfied: groq<1.0.0,>=0.30.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-groq>=0.2.0->apeswarm==0.1.0.dev0) (0.37.1)
Requirement already satisfied: ollama<1.0.0,>=0.6.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-ollama>=0.2.0->apeswarm==0.1.0.dev0) (0.6.1)
Requirement already satisfied: openai<3.0.0,>=2.20.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-openai>=0.2.0->apeswarm==0.1.0.dev0) (2.24.0)
Requirement already satisfied: tiktoken<1.0.0,>=0.7.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from langchain-openai>=0.2.0->apeswarm==0.1.0.dev0) (0.12.0)
Requirement already satisfied: tqdm>4 in /home/codespace/.python/current/lib/python3.12/site-packages (from openai<3.0.0,>=2.20.0->langchain-openai>=0.2.0->apeswarm==0.1.0.dev0) (4.67.3)
Requirement already satisfied: regex>=2022.1.18 in /home/codespace/.python/current/lib/python3.12/site-packages (from tiktoken<1.0.0,>=0.7.0->langchain-openai>=0.2.0->apeswarm==0.1.0.dev0) (2026.2.19)
Requirement already satisfied: charset_normalizer<4,>=2 in /home/codespace/.local/lib/python3.12/site-packages (from requests>=2.0.0->langsmith<1.0.0,>=0.3.45->langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (3.4.4)
Requirement already satisfied: urllib3<3,>=1.21.1 in /home/codespace/.local/lib/python3.12/site-packages (from requests>=2.0.0->langsmith<1.0.0,>=0.3.45->langchain-core<2.0.0,>=1.2.10->langchain>=0.3.0->apeswarm==0.1.0.dev0) (2.5.0)
Requirement already satisfied: markdown-it-py>=2.2.0 in /home/codespace/.python/current/lib/python3.12/site-packages (from rich>=13.0.0->apeswarm==0.1.0.dev0) (4.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/codespace/.local/lib/python3.12/site-packages (from rich>=13.0.0->apeswarm==0.1.0.dev0) (2.19.2)
Requirement already satisfied: mdurl~=0.1 in /home/codespace/.python/current/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=13.0.0->apeswarm==0.1.0.dev0) (0.1.2)
Building wheels for collected packages: apeswarm
  Building editable for apeswarm (pyproject.toml): started
  Building editable for apeswarm (pyproject.toml): finished with status 'done'
  Created wheel for apeswarm: filename=apeswarm-0.1.0.dev0-py3-none-any.whl size=3953 sha256=29820cf372d94ef3e069820c4859928ac084b801b0d4ced74dae7a6ccba97833
  Stored in directory: /tmp/pip-ephem-wheel-cache-qjxblajy/wheels/6e/b4/0d/a9ec7a9aa86941102c8ebfa83ab08f7d84119dbfa338143531
Successfully built apeswarm
Installing collected packages: apeswarm
  Attempting uninstall: apeswarm
    Found existing installation: apeswarm 0.1.0.dev0
    Uninstalling apeswarm-0.1.0.dev0:
      Successfully uninstalled apeswarm-0.1.0.dev0
Successfully installed apeswarm-0.1.0.dev0
- ───────────────────────────── 🦍 APE SWARM AWAKENS ─────────────────────────────
Goal: improve README and add a CONTRIBUTING.md

Config error: Missing required environment variable: XAI_API_KEY
Tip: Copy .env.example to .env and set your provider + API key.
  - startup works and fails gracefully with missing provider key (expected in clean env)
